### PR TITLE
Use `legal representative` instead of `legal rep`

### DIFF
--- a/docs/topics/accounts/closure/guide-close-link.mdx
+++ b/docs/topics/accounts/closure/guide-close-link.mdx
@@ -4,37 +4,37 @@ title: Send a link to close an account
 
 # Send a link to close an account
 
-If the account's [legal representative](../../../glossary.mdx#legal-representative) (legal rep) requests account closure, send them a link to complete the process.
+If the account's [legal representative](../../../glossary.mdx#legal-representative) requests account closure, send them a link to complete the process.
 
 :::caution Suspended accounts
 Only Swan can act on `Suspended` accounts.
 If the [status](../index.mdx#statuses) is `Suspended`, you can't send a link to close the account.
 :::
 
-## Step 1: Send link to legal rep {#send-link}
+## Step 1: Send link to legal representative {#send-link}
 
 1. Go to your **Dashboard** > **Data** > **Accounts**.
 1. Locate the account closure link in the **Close account** tile.
 1. **Click-to-copy** the link.
-1. Send the link to the account's legal rep.
+1. Send the link to the account's legal representative.
 
 :::note Tracking closure
 Keep track of the account closure process on **Dashboard** > **Data** > **Accounts**.
 Consider subscribing to the `Account.Closing` and `Account.Closed` [webhooks](../../../developers/using-api/webhooks.mdx#events-accounts) to be notified when the [account status](../index.mdx#statuses) changes.
 :::
 
-## Step 2: Legal rep completes process {#complete-process}
+## Step 2: Legal representative completes process {#complete-process}
 
-The account's legal rep opens the link you provide, then logs into their banking app.
+The account's legal representative opens the link you provide, then logs into their banking app.
 They choose a reason for account closure, then consent to closing the account with [Strong Customer Authentication](../../users/consent/index.mdx#sca).
 
 To complete the account closure process, the balance must be zero.
 The following table explains the actions required to reach a zero balance.
 
-| Balance | Action |
-| --- | --- |
+| Balance     | Action                                                                 |
+| ----------- | ---------------------------------------------------------------------- |
 | ➕ Positive | Transfer the funds **out of** the account with a SEPA Credit Transfer. |
-| ➖ Negative | Swan works with your end users to reach a zero balance. |
+| ➖ Negative | Swan works with your end users to reach a zero balance.                |
 
 :::tip Timeline
 After consenting to account closure and reaching a zero balance, the account is closed **within 30 days**.

--- a/docs/topics/onboarding/company/index.mdx
+++ b/docs/topics/onboarding/company/index.mdx
@@ -4,11 +4,11 @@ title: Company account onboarding
 
 # Company account onboarding
 
-import CompanyOnboardingDefinition from '../../definitions/_onboarding-company.mdx';
+import CompanyOnboardingDefinition from "../../definitions/_onboarding-company.mdx";
 
 > <CompanyOnboardingDefinition />
-> **Self-employed** users hold company accounts.
-Refer to the country requirements section for more information about identification for self-employed users.
+> **Self-employed** users hold company accounts. Refer to the country requirements
+> section for more information about identification for self-employed users.
 
 ## Process overview {#overview}
 
@@ -18,7 +18,7 @@ Company onboarding supports different types of organizations, including:
 - Self-employed workers
 - Associations or not-for-profit organizations
 
-import OnboardingOverview from '../partials/_overview.mdx';
+import OnboardingOverview from "../partials/_overview.mdx";
 
 <OnboardingOverview accountType="a company" />
 
@@ -30,7 +30,7 @@ Then, Swan collects the following information:
 1. User's **email address**.
 1. Legal information about the organization, including the **company name**, **registration number** (optional), **VAT number** (optional), and **address**, as well as details about the organization's **activity** and **expected monthly volume**.
 1. Information about the company's **ultimate beneficial owners** (UBO).
-This step only applies if the user selected **company**, **home owner association**, or **other** when submitting their preliminary details.
+   This step only applies if the user selected **company**, **home owner association**, or **other** when submitting their preliminary details.
 1. **Required documents** to verify your organization. You might not see this step in your onboarding process.
 1. User [**signs up**](../../users/index.mdx#signup) for Swan.
 
@@ -45,23 +45,24 @@ Swan must verify the identity of the [legal representative](../../../glossary.md
 Swan supports multiple [identification processes](../../users/identifications/index.mdx#levels-processes).
 For company onboarding, the following levels are recommended based on the account country.
 
-| Account country | Recommended level for legal rep | Other supported levels |
-|---|---|---|
-| 🇫🇷 France | **✓ Expert** | QES<br/>PVID |
-| 🇩🇪 Germany | **✓ Expert** | QES |
-| 🇮🇹 Italy | **✓ QES** | Expert + first transfer |
-| 🇳🇱 Netherlands | **✓ Expert** | QES<br/>PVID |
-| 🇪🇸 Spain | **✓ Expert** | QES<br/>PVID |
+| Account country | Recommended level for legal representative | Other supported levels  |
+| --------------- | ------------------------------------------ | ----------------------- |
+| 🇫🇷 France       | **✓ Expert**                               | QES<br/>PVID            |
+| 🇩🇪 Germany      | **✓ Expert**                               | QES                     |
+| 🇮🇹 Italy        | **✓ QES**                                  | Expert + first transfer |
+| 🇳🇱 Netherlands  | **✓ Expert**                               | QES<br/>PVID            |
+| 🇪🇸 Spain        | **✓ Expert**                               | QES<br/>PVID            |
 
 :::info Self-employed account holders
+
 - **France unregistered self-employed**: PVID, or Expert and a first transfer to your Swan account (QES is technically accepted but not preferred)
 - **France registered self-employed**: Expert
 - **Germany self-employed**: QES and a first transfer to your Swan account
-:::
+  :::
 
 ## Country requirements for company accounts {#country-reqs}
 
-import CountryReqs from '../partials/_country-reqs.mdx';
+import CountryReqs from "../partials/_country-reqs.mdx";
 
 <CountryReqs thisAccountType="company" thatAccountType="individual" />
 
@@ -74,34 +75,34 @@ If the cell is empty, the field is optional.
 
 ### Company and account holder information {#country-reqs-company-account-holder}
 
-| API field | 🇫🇷<br/>France | 🇩🇪<br/>Germany | 🇮🇹<br/>Italy | 🇳🇱<br/>Netherlands | 🇪🇸<br/>Spain |
-|---|---|---|---|---|---|
-|`accountCountry`| ✓ Required (**FRA**) | ✓ Required (**DEU**) | ✓ Required (**ITA**) | ✓ Required (**NLD**) | ✓ Required (**ESP**) |
-|`accountName`|  |  |  |  |  |
-|`businessActivity`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`businessActivityDescription`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`companyType`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`email`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`isRegistered`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`language`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`monthlyPaymentVolume`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`name` *(company name)* | ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`redirectUrl`|  |  |  |  |  |
-|`registrationNumber`<br/>*(if registered)* | ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`residencyAddress.addressLine1`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`residencyAddress.addressLine2`|  |  |  |  |  |
-|`residencyAddress.city`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`residencyAddress.country`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`residencyAddress.postalCode`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`residencyAddress.state`|  |  |  |  |  |
-|`taxIdentificationNumber`|  | ∗ 90 days | |  | ﹖ Conditional |
-|`typeOfRepresentation`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`vatNumber`|  |  |  |  |  |
+| API field                                  | 🇫🇷<br/>France        | 🇩🇪<br/>Germany       | 🇮🇹<br/>Italy         | 🇳🇱<br/>Netherlands   | 🇪🇸<br/>Spain         |
+| ------------------------------------------ | -------------------- | -------------------- | -------------------- | -------------------- | -------------------- |
+| `accountCountry`                           | ✓ Required (**FRA**) | ✓ Required (**DEU**) | ✓ Required (**ITA**) | ✓ Required (**NLD**) | ✓ Required (**ESP**) |
+| `accountName`                              |                      |                      |                      |                      |                      |
+| `businessActivity`                         | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           |
+| `businessActivityDescription`              | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           |
+| `companyType`                              | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           |
+| `email`                                    | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           |
+| `isRegistered`                             | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           |
+| `language`                                 | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           |
+| `monthlyPaymentVolume`                     | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           |
+| `name` _(company name)_                    | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           |
+| `redirectUrl`                              |                      |                      |                      |                      |                      |
+| `registrationNumber`<br/>_(if registered)_ | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           |
+| `residencyAddress.addressLine1`            | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           |
+| `residencyAddress.addressLine2`            |                      |                      |                      |                      |                      |
+| `residencyAddress.city`                    | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           |
+| `residencyAddress.country`                 | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           |
+| `residencyAddress.postalCode`              | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           |
+| `residencyAddress.state`                   |                      |                      |                      |                      |                      |
+| `taxIdentificationNumber`                  |                      | ∗ 90 days            |                      |                      | ﹖ Conditional       |
+| `typeOfRepresentation`                     | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           | ✓ Required           |
+| `vatNumber`                                |                      |                      |                      |                      |                      |
 
-﹖ *Required if both the `accountCountry` and `residencyAddress.country` are Spain.*
+﹖ _Required if both the `accountCountry` and `residencyAddress.country` are Spain._
 
-∗ *If the `accountCountry` is Germany, the account holder has 90 days to provide their Tax ID Number when opening an account.
-Otherwise, the account is suspended.*
+∗ _If the `accountCountry` is Germany, the account holder has 90 days to provide their Tax ID Number when opening an account.
+Otherwise, the account is suspended._
 
 ### Ultimate beneficial owner (UBO) information {#country-reqs-ubo}
 
@@ -111,27 +112,27 @@ If your company **doesn't have a UBO**, these fields can be left **empty**.
 **UBO** stands for a portion of the API field: `individualUltimateBeneficialOwners`.
 :::
 
-| API field | 🇫🇷<br/>France | 🇩🇪<br/>Germany | 🇮🇹<br/>Italy | 🇳🇱<br/>Netherlands | 🇪🇸<br/>Spain |
-|---|---|---|---|---|---|
-|`UBO.birthCity`| ✓ Required | | ✓ Required | ✓ Required | ✓ Required |
-|`UBO.birthCityPostalCode`| ✓ Required | | ✓ Required | ✓ Required | |
-|`UBO.birthCountryCode`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`UBO.birthDate`| ✓ Required |  | ✓ Required | ✓ Required | ✓ Required |
-|`UBO.direct`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`UBO.indirect`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`UBO.firstName`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`UBO.lastName`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`UBO.residencyAddress.addressLine1`|  | ✓ Required | ✓ Required |  | ✓ Required |
-|`UBO.residencyAddress.addressLine2`| | | | | |
-|`UBO.residencyAddress.city`|  | ✓ Required |  ✓ Required | | ✓ Required |
-|`UBO.residencyAddress.country`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`UBO.residencyAddress.postalCode`| | ✓ Required | ✓ Required |  | ✓ Required |
-|`UBO.residencyAddress.state`| | | | | |
-|`UBO.taxIdentificationNumber`| | ﹖ Conditional | ✓ Required | | |
-|`UBO.totalCapitalPercentage`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`UBO.type`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
+| API field                           | 🇫🇷<br/>France | 🇩🇪<br/>Germany | 🇮🇹<br/>Italy | 🇳🇱<br/>Netherlands | 🇪🇸<br/>Spain |
+| ----------------------------------- | ------------- | -------------- | ------------ | ------------------ | ------------ |
+| `UBO.birthCity`                     | ✓ Required    |                | ✓ Required   | ✓ Required         | ✓ Required   |
+| `UBO.birthCityPostalCode`           | ✓ Required    |                | ✓ Required   | ✓ Required         |              |
+| `UBO.birthCountryCode`              | ✓ Required    | ✓ Required     | ✓ Required   | ✓ Required         | ✓ Required   |
+| `UBO.birthDate`                     | ✓ Required    |                | ✓ Required   | ✓ Required         | ✓ Required   |
+| `UBO.direct`                        | ✓ Required    | ✓ Required     | ✓ Required   | ✓ Required         | ✓ Required   |
+| `UBO.indirect`                      | ✓ Required    | ✓ Required     | ✓ Required   | ✓ Required         | ✓ Required   |
+| `UBO.firstName`                     | ✓ Required    | ✓ Required     | ✓ Required   | ✓ Required         | ✓ Required   |
+| `UBO.lastName`                      | ✓ Required    | ✓ Required     | ✓ Required   | ✓ Required         | ✓ Required   |
+| `UBO.residencyAddress.addressLine1` |               | ✓ Required     | ✓ Required   |                    | ✓ Required   |
+| `UBO.residencyAddress.addressLine2` |               |                |              |                    |              |
+| `UBO.residencyAddress.city`         |               | ✓ Required     | ✓ Required   |                    | ✓ Required   |
+| `UBO.residencyAddress.country`      | ✓ Required    | ✓ Required     | ✓ Required   | ✓ Required         | ✓ Required   |
+| `UBO.residencyAddress.postalCode`   |               | ✓ Required     | ✓ Required   |                    | ✓ Required   |
+| `UBO.residencyAddress.state`        |               |                |              |                    |              |
+| `UBO.taxIdentificationNumber`       |               | ﹖ Conditional | ✓ Required   |                    |              |
+| `UBO.totalCapitalPercentage`        | ✓ Required    | ✓ Required     | ✓ Required   | ✓ Required         | ✓ Required   |
+| `UBO.type`                          | ✓ Required    | ✓ Required     | ✓ Required   | ✓ Required         | ✓ Required   |
 
-﹖ *Required if both the `accountCountry` and the UBO's `residencyAddress.country` are Germany.*
+﹖ _Required if both the `accountCountry` and the UBO's `residencyAddress.country` are Germany._
 
 ### Legal representative information {#country-reqs-legal-rep}
 
@@ -139,14 +140,14 @@ If your company **doesn't have a UBO**, these fields can be left **empty**.
 **lr** stands for a portion of the API field: `legalRepresentative`.
 :::
 
-| API field | 🇫🇷<br/>France | 🇩🇪<br/>Germany | 🇮🇹<br/>Italy | 🇳🇱<br/>Netherlands | 🇪🇸<br/>Spain |
-|---|---|---|---|---|---|
-|`lrPersonalAddress.addressLine1`| | ✓ Required | ✓ Required | ✓ Required | |
-|`lrPersonalAddress.addressLine2`| | | | | |
-|`lrPersonalAddress.city`| | ✓ Required | ✓ Required | ✓ Required | |
-|`lrPersonalAddress.country`| | ✓ Required | ✓ Required | ✓ Required | |
-|`lrPersonalAddress.postalCode`| | ✓ Required | ✓ Required | ✓ Required | |
-|`lrPersonalAddress.state`| | | | | |
+| API field                        | 🇫🇷<br/>France | 🇩🇪<br/>Germany | 🇮🇹<br/>Italy | 🇳🇱<br/>Netherlands | 🇪🇸<br/>Spain |
+| -------------------------------- | ------------- | -------------- | ------------ | ------------------ | ------------ |
+| `lrPersonalAddress.addressLine1` |               | ✓ Required     | ✓ Required   | ✓ Required         |              |
+| `lrPersonalAddress.addressLine2` |               |                |              |                    |              |
+| `lrPersonalAddress.city`         |               | ✓ Required     | ✓ Required   | ✓ Required         |              |
+| `lrPersonalAddress.country`      |               | ✓ Required     | ✓ Required   | ✓ Required         |              |
+| `lrPersonalAddress.postalCode`   |               | ✓ Required     | ✓ Required   | ✓ Required         |              |
+| `lrPersonalAddress.state`        |               |                |              |                    |              |
 
 ## User flow diagrams {#diagrams}
 
@@ -161,9 +162,9 @@ If your company **doesn't have a UBO**, these fields can be left **empty**.
   </div>
 </details>
 
-## Guides  {#guides}
+## Guides {#guides}
 
 Use the following guides to start and complete the company onboarding process.
 
-* [Create a company onboarding link](./guide-create.mdx)
-* [Update a company onboarding](./guide-update.mdx)
+- [Create a company onboarding link](./guide-create.mdx)
+- [Update a company onboarding](./guide-update.mdx)

--- a/docs/topics/users/consent/guide-implement-s2s.mdx
+++ b/docs/topics/users/consent/guide-implement-s2s.mdx
@@ -11,15 +11,16 @@ title: Implement server-to-server (S2S) consent
 Use your browser's cryptography API to generate your key pair according to the [required algorithm](./index.mdx#s2s-cryptography).
 
 ```js title="Request" showLineNumbers
-await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, ["sign", "verify"])
+await crypto.subtle
+  .generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, ["sign", "verify"])
   .then(async ({ publicKey, privateKey }) => ({
     publicKey: await crypto.subtle.exportKey("jwk", publicKey),
     privateKey: await crypto.subtle.exportKey("jwk", privateKey),
   }))
-  .then(keys => ({
+  .then((keys) => ({
     publicKey: JSON.stringify(keys.publicKey),
     privateKey: JSON.stringify(keys.privateKey),
-}));
+  }));
 ```
 
 The request generates a response similar to the following sample.
@@ -54,7 +55,7 @@ After you save your public key, Swan sends a text message to your [project's leg
 Now that you have a private key stored securely on your server and a public key installed in your Swan Dashboard, you can use the keys to grant S2S consent.
 
 :::tip Impersonation
-If the user access token attributed to your [project's legal representative](./index.mdx#s2s-project-legal-rep) expires and interrupts your process, consider [impersonating the legal rep with a project access token](../../../developers/using-api/authentication/guide-impersonate.mdx) instead.
+If the user access token attributed to your [project's legal representative](./index.mdx#s2s-project-legal-rep) expires and interrupts your process, consider [impersonating the legal representative with a project access token](../../../developers/using-api/authentication/guide-impersonate.mdx) instead.
 :::
 
 ### 3.1 Get consent challenge {#consent-private-challenge-get}
@@ -89,8 +90,8 @@ Next, sign the `challenge` using the following script, the provided library, and
 
 ```js showLineNumbers
 await signAndExportJwtToken("$YOUR_PRIVATE_KEY_JWK", {
-   header: { alg: "ES256", typ: "JWT" },
-   payload: { challenge: "$YOUR_CONSENT_CHALLENGE" },
+  header: { alg: "ES256", typ: "JWT" },
+  payload: { challenge: "$YOUR_CONSENT_CHALLENGE" },
 });
 ```
 
@@ -198,7 +199,7 @@ mutation GrantS2s {
 
 You can replace or revoke an installed public key at any time.
 
-import ReplacePublicKey from './_s2s-replace-key.mdx';
+import ReplacePublicKey from "./_s2s-replace-key.mdx";
 
 <ReplacePublicKey />
 

--- a/docs/topics/users/consent/index.mdx
+++ b/docs/topics/users/consent/index.mdx
@@ -30,20 +30,23 @@ If this could be helpful for your use case, please discuss delegating SCA with y
 
 ### SCA user experience {#sca-user}
 
-Though there's much more happening technically, the user experience to consent to sensitive operations is straightforward and typically quick. 
+Though there's much more happening technically, the user experience to consent to sensitive operations is straightforward and typically quick.
 
 1. The user **opens the consent URL**.
-    1. **Computer**: they receive the consent link in a text message from Swan or a notification from you. The user opens the link and follows the instructions.
-    1. **Mobile device**: they're redirected to the correct page.
+   1. **Computer**: they receive the consent link in a text message from Swan or a notification from you. The user opens the link and follows the instructions.
+   1. **Mobile device**: they're redirected to the correct page.
 1. If the user **doesn't receive a text message**, they can either request the text message be sent again or consent by scanning a QR code.
 1. The user **verifies their identity** by entering their 6-digit passcode or using biometrics.
 1. The user is then redirected to your predefined `redirectUrl`.
 
 <details>
   <summary>Video completing Strong Customer Authentication on mobile</summary>
-    <div>
-        <img src={require("../../../images/topics/users/consent/sca-flow.gif").default} alt="Map of Swan coverage for individual and company accounts" />
-    </div>
+  <div>
+    <img
+      src={require("../../../images/topics/users/consent/sca-flow.gif").default}
+      alt="Map of Swan coverage for individual and company accounts"
+    />
+  </div>
 </details>
 
 :::caution Text message and link validity
@@ -75,21 +78,21 @@ Mutations marked with the symbol ⮂ are eligible for [server-to-server consent]
 <h3 id="sensitive-cards">Cards</h3>
 
 - **Adding cards**:
-    - [`addCard`](https://api-reference.swan.io/mutations/add-card/) ⮂
-    - [`addCards`](https://api-reference.swan.io/mutations/add-cards/) ⮂
-    - [`addCardsWithGroupDelivery`](https://api-reference.swan.io/mutations/add-cards-with-group-delivery/) ⮂
-    - [`addDigitalCard`](https://api-reference.swan.io/mutations/add-digital-card/)
-    - [`addSingleUseVirtualCard`](https://api-reference.swan.io/mutations/add-single-use-virtual-card/) ⮂
-    - [`addSingleUseVirtualCards`](https://api-reference.swan.io/mutations/add-single-use-virtual-cards/) ⮂
+  - [`addCard`](https://api-reference.swan.io/mutations/add-card/) ⮂
+  - [`addCards`](https://api-reference.swan.io/mutations/add-cards/) ⮂
+  - [`addCardsWithGroupDelivery`](https://api-reference.swan.io/mutations/add-cards-with-group-delivery/) ⮂
+  - [`addDigitalCard`](https://api-reference.swan.io/mutations/add-digital-card/)
+  - [`addSingleUseVirtualCard`](https://api-reference.swan.io/mutations/add-single-use-virtual-card/) ⮂
+  - [`addSingleUseVirtualCards`](https://api-reference.swan.io/mutations/add-single-use-virtual-cards/) ⮂
 - **Virtual cards**:
-    - [`updateCard`](https://api-reference.swan.io/mutations/update-card/) ⮂
-    - [`viewCardNumbers`](https://api-reference.swan.io/mutations/view-card-numbers/)
+  - [`updateCard`](https://api-reference.swan.io/mutations/update-card/) ⮂
+  - [`viewCardNumbers`](https://api-reference.swan.io/mutations/view-card-numbers/)
 - **Physical cards**:
-    - [`printPhysicalCard`](https://api-reference.swan.io/mutations/print-physical-card/) ⮂
-    - [`activatePhysicalCard`](https://api-reference.swan.io/mutations/activate-physical-card/) ⮂
-    - [`resumePhysicalCard`](https://api-reference.swan.io/mutations/resume-physical-card/) ⮂
-    - [`viewPhysicalCardNumbers`](https://api-reference.swan.io/mutations/view-physical-card-numbers/)
-    - [`viewPhysicalCardPin`](https://api-reference.swan.io/mutations/view-physical-card-pin/)
+  - [`printPhysicalCard`](https://api-reference.swan.io/mutations/print-physical-card/) ⮂
+  - [`activatePhysicalCard`](https://api-reference.swan.io/mutations/activate-physical-card/) ⮂
+  - [`resumePhysicalCard`](https://api-reference.swan.io/mutations/resume-physical-card/) ⮂
+  - [`viewPhysicalCardNumbers`](https://api-reference.swan.io/mutations/view-physical-card-numbers/)
+  - [`viewPhysicalCardPin`](https://api-reference.swan.io/mutations/view-physical-card-pin/)
 
 <h3 id="sensitive-funding">Funding</h3>
 
@@ -99,15 +102,15 @@ Mutations marked with the symbol ⮂ are eligible for [server-to-server consent]
 <h3 id="sensitive-payments-transactions">Payments and transactions</h3>
 
 - **Credit transfers**:
-    - [`initiateCreditTransfers`](https://api-reference.swan.io/mutations/initiate-credit-transfers/) ⮂
-    - [`initiateInternationalCreditTransfer`](https://api-reference.swan.io/mutations/initiate-international-credit-transfer/) ⮂
-    - [`scheduleStandingOrder`](https://api-reference.swan.io/mutations/schedule-standing-order/) ⮂
+  - [`initiateCreditTransfers`](https://api-reference.swan.io/mutations/initiate-credit-transfers/) ⮂
+  - [`initiateInternationalCreditTransfer`](https://api-reference.swan.io/mutations/initiate-international-credit-transfer/) ⮂
+  - [`scheduleStandingOrder`](https://api-reference.swan.io/mutations/schedule-standing-order/) ⮂
 - **Direct debit payment mandates**:
-    - [`addReceivedSepaDirectDebitB2bMandate`](https://api-reference.swan.io/mutations/add-received-sepa-direct-debit-b2-b-mandate/) ⮂
-    - [`enableReceivedDirectDebitMandate`](https://api-reference.swan.io/mutations/enable-received-direct-debit-mandate/) ⮂
-    - [`updateReceivedSepaDirectDebitB2bMandate`](https://api-reference.swan.io/mutations/update-received-sepa-direct-debit-b2-b-mandate/) ⮂
+  - [`addReceivedSepaDirectDebitB2bMandate`](https://api-reference.swan.io/mutations/add-received-sepa-direct-debit-b2-b-mandate/) ⮂
+  - [`enableReceivedDirectDebitMandate`](https://api-reference.swan.io/mutations/enable-received-direct-debit-mandate/) ⮂
+  - [`updateReceivedSepaDirectDebitB2bMandate`](https://api-reference.swan.io/mutations/update-received-sepa-direct-debit-b2-b-mandate/) ⮂
 - **Other**:
-    - [`refund`](https://api-reference.swan.io/mutations/refund/) ⮂
+  - [`refund`](https://api-reference.swan.io/mutations/refund/) ⮂
 
 ## Multi-consents {#multi-consent}
 
@@ -172,21 +175,21 @@ Keys must respect the following algorithm:
 You'll [install the public key](./guide-implement-s2s.mdx#install-public) on your Dashboard, and it will be used to verify the server signature for all S2S operations.
 You're required to keep the corresponding private key secure on your side.
 
-import ReplacePublicKey from './_s2s-replace-key.mdx';
+import ReplacePublicKey from "./_s2s-replace-key.mdx";
 
 <ReplacePublicKey />
 
-### Role of projects and legal reps {#s2s-project-legal-rep}
+### Role of projects and legal representatives {#s2s-project-legal-rep}
 
 For security and regulatory purposes, server-to-server consent is **bound to a project**, more specifically to the **project's [legal representative](../../../glossary.mdx#legal-representative)**.
 You can't apply S2S consent configured in one project to operations in another project.
 Instead, implement S2S consent in both projects independently.
 
 The keys, both public and private, are attributed to the project's legal representative.
-Only the legal rep can perform operations with server-to-server consent.
-With consent, you can also [impersonate the legal rep](../../../developers/using-api/authentication/index.mdx#tokens-project-impersonate) with a project access token.
+Only the legal representative can perform operations with server-to-server consent.
+With consent, you can also [impersonate the legal representative](../../../developers/using-api/authentication/index.mdx#tokens-project-impersonate) with a project access token.
 
-Any operation required to [set up or modify S2S consent](./guide-implement-s2s.mdx) (such as installing the public key or adding IP addresses) must be consented to by the legal rep using [Strong Customer Authentication](./index.mdx#sca).
+Any operation required to [set up or modify S2S consent](./guide-implement-s2s.mdx) (such as installing the public key or adding IP addresses) must be consented to by the legal representative using [Strong Customer Authentication](./index.mdx#sca).
 
 ## Consent statuses {#statuses}
 
@@ -218,16 +221,16 @@ flowchart LR
     style V fill:#dfedf2,stroke:#4d8296,stroke-width:3px
 ```
 
-| Consent status | Explanation |
-|---|---|
-| `Created` | A sensitive operation was initiated, triggering the creation of a consent request automatically. The user who needs to consent hasn't opened the consent URL yet.  |
-| `Started` | The user opened the consent URL but hasn't consented yet. |
-| `Accepted` | The user consented successfully. |
-| `Canceled` | Consent requests can be `Canceled` by you or your user as long as the consent has a non-final status. `Canceled` also applies to child consents when a preceding child consent `Failed`. |
-| `CustomerRefused` | The user refused to consent to the sensitive operation. |
-| `Expired` | The user opened the consent URL, but didn't consent within the 20-minute validity window. This also applies if the user tries to consent but can't manage to complete a valid consent within the 20 minutes. |
-| `OperationCommitting`<br />*(multi-consent only)* | A multi-consent was executed, and one or more child consents are still in progress.<br /><br />**Next steps:**<ul><li>If consent is provided for all child consents, meaning all child consents have the status `Accepted`, the status of the multi-consent changes to `Accepted`.</li><li>If a single child consent has the status `Failed`, the multi-consent is also assigned the status `Failed`. </li></ul> |
-| `Failed`<br />*(multi-consent only)* | A child consent `Failed`, meaning the multi-consent also `Failed`. All child consents that are already `Accepted` remain valid, but all child consents that haven't been executed yet are `Canceled`. |
+| Consent status                                    | Explanation                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Created`                                         | A sensitive operation was initiated, triggering the creation of a consent request automatically. The user who needs to consent hasn't opened the consent URL yet.                                                                                                                                                                                                                                                |
+| `Started`                                         | The user opened the consent URL but hasn't consented yet.                                                                                                                                                                                                                                                                                                                                                        |
+| `Accepted`                                        | The user consented successfully.                                                                                                                                                                                                                                                                                                                                                                                 |
+| `Canceled`                                        | Consent requests can be `Canceled` by you or your user as long as the consent has a non-final status. `Canceled` also applies to child consents when a preceding child consent `Failed`.                                                                                                                                                                                                                         |
+| `CustomerRefused`                                 | The user refused to consent to the sensitive operation.                                                                                                                                                                                                                                                                                                                                                          |
+| `Expired`                                         | The user opened the consent URL, but didn't consent within the 20-minute validity window. This also applies if the user tries to consent but can't manage to complete a valid consent within the 20 minutes.                                                                                                                                                                                                     |
+| `OperationCommitting`<br />_(multi-consent only)_ | A multi-consent was executed, and one or more child consents are still in progress.<br /><br />**Next steps:**<ul><li>If consent is provided for all child consents, meaning all child consents have the status `Accepted`, the status of the multi-consent changes to `Accepted`.</li><li>If a single child consent has the status `Failed`, the multi-consent is also assigned the status `Failed`. </li></ul> |
+| `Failed`<br />_(multi-consent only)_              | A child consent `Failed`, meaning the multi-consent also `Failed`. All child consents that are already `Accepted` remain valid, but all child consents that haven't been executed yet are `Canceled`.                                                                                                                                                                                                            |
 
 ## Consent sequence diagrams {#consent-diagrams}
 
@@ -236,7 +239,7 @@ flowchart LR
 If your user is on a computer, their consent flow depends on your [notification settings](#notifications).
 They'll either receive a **text message from Swan** (arrows 6-8) or a **notification from you** (arrows 9-12).
 
-Users are guided through a  similar but slightly different flow for online payments that require [3-D Secure consent](../../payments/cards/index.mdx#3ds).
+Users are guided through a similar but slightly different flow for online payments that require [3-D Secure consent](../../payments/cards/index.mdx#3ds).
 
 ```mermaid
 sequenceDiagram
@@ -304,7 +307,7 @@ participant UM as User's mobile device
 To trigger the S2S sequence, your user sends you a request.
 This diagram completes the operation with server-to-server consent.
 
-*Note that the diagram doesn't illustrate how you communicate with your user.*
+_Note that the diagram doesn't illustrate how you communicate with your user._
 
 ```mermaid
 sequenceDiagram
@@ -323,13 +326,20 @@ participant S as Swan API
 ### Diagram: End-user perspective {#consent-diagrams-end-user}
 
 <details>
-  <summary>End-user perspective of consenting to add an account membership</summary>
+  <summary>
+    End-user perspective of consenting to add an account membership
+  </summary>
   <div>
-    <iframe src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F7K15ufXZK7Zgan770kkTmq%2FUser-flow-diagrams%3Ftype%3Ddesign%26node-id%3D1%253A563%26mode%3Ddesign%26t%3DoGQbGo0SuPiYeJMG-1" allowFullScreen style={{width: "100%", height: 400}}></iframe>
+    <iframe
+      src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F7K15ufXZK7Zgan770kkTmq%2FUser-flow-diagrams%3Ftype%3Ddesign%26node-id%3D1%253A563%26mode%3Ddesign%26t%3DoGQbGo0SuPiYeJMG-1"
+      allowFullScreen
+      style={{ width: "100%", height: 400 }}
+    ></iframe>
   </div>
 </details>
 
 ## Guides {#guides}
+
 - [Configure notifications and specify preferences](./guide-configure-notifications.mdx)
 - [Create a multi-consent](./guide-create-multiconsent.mdx)
 - [Implement server-to-server consent](./guide-implement-s2s.mdx)


### PR DESCRIPTION
Small suggestion, I noticed the usage of the term `legal rep` in the account closing doc and find that it's not really useful to use it in place of the full `legal representative` one (and might make it harder to search).
