### PR TITLE
fix parameter type in create payment link doc example code snippet

### DIFF
--- a/docs/topics/merchants/online/cards/guide-create-link.mdx
+++ b/docs/topics/merchants/online/cards/guide-create-link.mdx
@@ -41,7 +41,7 @@ mutation PaymentLink {
     input: {
       merchantProfileId: "$MERCHANT_PROFILE_ID"
       amount: { value: "50", currency: "EUR" }
-      paymentMethodIds: "$PAYMENT_METHOD_ID"
+      paymentMethodIds: ["$PAYMENT_METHOD_ID"]
       label: "Your custom label"
       reference: "YourReference"
     }


### PR DESCRIPTION
This is fixing the type that is in the doc of the mutation [CreateMerchantPaymentLink](https://api-reference.swan.io/inputs/create-merchant-payment-link-input) (link of the documentation: https://docs.swan.io/topics/merchants/online/cards/guide-create-link)

In the doc, the "paymentMethodIds" is passed a string, this pull request passes an array of string.