### PR TITLE
DOC-878 remove Gabon from acceptable identity documents entirely

### DIFF
--- a/docs/partnership/document-center/identity/expert.mdx
+++ b/docs/partnership/document-center/identity/expert.mdx
@@ -119,11 +119,6 @@ import IdDocumentsIntro from '../partials/_intro-id.mdx';
         <td>✓ Passport</td>
     </tr>
     <tr>
-        <td>🇬🇦 Gabon</td>
-        <td></td>
-        <td>✓ Passport</td>
-    </tr>
-    <tr>
         <td>🇬🇲 Gambia</td>
         <td></td>
         <td>✓ Passport</td>

--- a/docs/topics/accounts/documents/guide-upload-transaction.mdx
+++ b/docs/topics/accounts/documents/guide-upload-transaction.mdx
@@ -111,7 +111,7 @@ The `url` is **only valid for seven days**, after which you'd need to generate a
 ## Step 4: Send POST request {#guide-send-post}
 
 Send an HTTP POST request to the `url` without a `Content-Type` header using the following cURL command.
-Supported file formats are `.pdf`, `.png`, and `.jpg`.
+Supported file formats are `.heic`, `.jpg`, `.pdf`, and `.png`.
 
 ```curl showLineNumbers
 curl --location --request POST '$UPLOAD_URL' \


### PR DESCRIPTION
Previous update only removed identity card, but passports aren't valid either.