### PR TITLE
Doc 891/first transfer restrictions

### DIFF
--- a/docs/topics/onboarding/account-holders/index.mdx
+++ b/docs/topics/onboarding/account-holders/index.mdx
@@ -113,8 +113,8 @@ A first transfer is always required for self-employed and individual accounts fo
 :::
 
 Users must send first transfers from a bank account in their name.
-Transfers from third-party payment platforms and online banking services aren’t accepted. 
-Send your users the Swan Support Center article explaining the platforms that aren't accepted for a [first transfer request](https://support.swan.io/hc/en-150/articles/17774309993501-First-transfer-request).
+First transfers from third-party payment platforms and online banking services aren’t accepted. 
+Send your users the [Support Center article](https://support.swan.io/hc/en-150/articles/17774309993501-First-transfer-request) listing the platforms that aren't accepted for a first transfer.
 
 Users can send any amount in the first transfer.
 While there is technically no deadline for sending the transfer, the user's [account is `Limited`](../../accounts/index.mdx#account-type-level) until the transfer is validated.

--- a/docs/topics/onboarding/account-holders/index.mdx
+++ b/docs/topics/onboarding/account-holders/index.mdx
@@ -114,7 +114,8 @@ A first transfer is always required for self-employed and individual accounts fo
 
 Users must send first transfers from a bank account in their name.
 First transfers from third-party payment platforms and online banking services aren’t accepted. 
-Send your users the [Support Center article](https://support.swan.io/hc/en-150/articles/17774309993501-First-transfer-request) listing the platforms that aren't accepted for a first transfer.
+Share this [Support Center article](https://support.swan.io/hc/en-150/articles/17774309993501-First-transfer-request) with your users. 
+It lists the platforms and online banking services that aren't accepted for a first transfer.
 
 Users can send any amount in the first transfer.
 While there is technically no deadline for sending the transfer, the user's [account is `Limited`](../../accounts/index.mdx#account-type-level) until the transfer is validated.

--- a/docs/topics/onboarding/account-holders/index.mdx
+++ b/docs/topics/onboarding/account-holders/index.mdx
@@ -113,7 +113,8 @@ A first transfer is always required for self-employed and individual accounts fo
 :::
 
 Users must send first transfers from a bank account in their name.
-Transfers from third-party payment platforms like PayPal or Lydia aren't accepted.
+Transfers from third-party payment platforms and online banking services aren’t accepted. 
+Send your users the Swan Support Center article explaining the platforms that aren't accepted for a [first transfer request](https://support.swan.io/hc/en-150/articles/17774309993501-First-transfer-request).
 
 Users can send any amount in the first transfer.
 While there is technically no deadline for sending the transfer, the user's [account is `Limited`](../../accounts/index.mdx#account-type-level) until the transfer is validated.


### PR DESCRIPTION
Improved the explanation for first transfer restrictions according to following these instructions:

- **Docs** - improve the explanation about the type of bank we don't accept.

- **Support Center** - maintain the full list.

Support article is linked in the text to direct partner to the full list. 