### PR TITLE
Doc 970/italian iban update

### DIFF
--- a/docs/topics/onboarding/company/index.mdx
+++ b/docs/topics/onboarding/company/index.mdx
@@ -208,7 +208,10 @@ However, for `individualUltimateBeneficialOwners.type`, please indicate `LegalRe
 |`UBO.totalCapitalPercentage`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
 |`UBO.type`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
 
-﹖ *Required if both the `accountCountry` and the UBO's `residencyAddress.country` are Germany.*
+> ∗ *If the `accountCountry` is Germany, the UBO has 90 days to provide their Tax ID Number when opening an account.
+Otherwise, the account is `Suspended`.
+Share [Swan's Support Center article](https://support.swan.io/hc/en-150/articles/21876111550621-German-Tax-identification-number-Tax-ID) if your UBOs have concerns.*
+>
 
 ### Legal representative information {#country-reqs-legal-rep}
 

--- a/docs/topics/onboarding/company/index.mdx
+++ b/docs/topics/onboarding/company/index.mdx
@@ -163,9 +163,9 @@ If the cell is empty, the field is optional.
 |`residencyAddress.country`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
 |`residencyAddress.postalCode`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
 |`residencyAddress.state`|  |  |  |  |  |
-|`taxIdentificationNumber`|  | ✓ Required (∗ 90 days) | |  | ﹖ Conditional |
+|`taxIdentificationNumber`|  | ✓ Required (∗ 90 days) |✓ Required |  | ﹖ Conditional |
 |`typeOfRepresentation`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
-|`vatNumber`|  |  |  |  |  |
+|`vatNumber`|  |  | ✓ Required |  |  |
 
 > ^ *`isRegistered` must be `true` and the `registrationNumber` provided for **all onboardings** where `companyType` is `Company`.
 This also applies when `companyType` is `SelfEmployed` **and** the account country is `France`.
@@ -204,7 +204,7 @@ However, for `individualUltimateBeneficialOwners.type`, please indicate `LegalRe
 |`UBO.residencyAddress.country`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
 |`UBO.residencyAddress.postalCode`| | ✓ Required | ✓ Required |  | ✓ Required |
 |`UBO.residencyAddress.state`| | | | | |
-|`UBO.taxIdentificationNumber`| | ﹖ Conditional | ✓ Required | | |
+|`UBO.taxIdentificationNumber`| | ✓ Required (∗ 90 days) | ✓ Required | | |
 |`UBO.totalCapitalPercentage`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
 |`UBO.type`| ✓ Required | ✓ Required | ✓ Required | ✓ Required | ✓ Required |
 


### PR DESCRIPTION
Updates:

- Company and account holder information: tick for Italy on VAT number and tax identification number
- UBO information: tick for tax identification number and change the German statement from conditional to required, 90 days (added an explanation in the footnotes).