### PR TITLE
fixup! Merge pull request #280 from swan-io/DOC-928/new-notifications

### DIFF
--- a/docs/topics/projects/index.mdx
+++ b/docs/topics/projects/index.mdx
@@ -71,7 +71,8 @@ If you have a Live project and you'd like to test an implementation in Sandbox b
 
 ## Notifications {#notifications}
 
-Send text message notifications to your end users automatically when certain events occur.
+Send notifications to your end users automatically when certain events occur. 
+Notifications are delivered in the [account membership language](../accounts/memberships/index.mdx#language).
 
 The following tables list information about the available text message and email notifications.
 Take note of the [account membership permissions](../accounts/memberships/index.mdx#permissions) required to receive each notification.


### PR DESCRIPTION
Removed the following sentence from the changelog as it was repetitive, and I added it to the docs instead:
Notifications are delivered in the account membership language (https://docs.swan.io/topics/accounts/memberships/#language).