### PR TITLE
Fixed Docusaurus version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Swan Docs
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
 
 ## Installation
 


### PR DESCRIPTION
The Docusaurus version was upgraded to 3 in #38. Since maintaining the versioning can be a constant maintenance effort, I've removed the mention of the version.