### PR TITLE
Corrected step in guide

### DIFF
--- a/docs/topics/capital-deposits/france/guide-upload-documents.mdx
+++ b/docs/topics/capital-deposits/france/guide-upload-documents.mdx
@@ -5,7 +5,7 @@ title: Upload required documents
 # Upload required documents
 
 :::caution Multi-step process
-This page explains how to upload documents for steps 4 and 8 of a **multi-step process**.
+This page explains how to upload documents for steps 2 and 8 of a **multi-step process**.
 Refer to the [France guide](./guide.mdx) for the whole process.
 :::
 


### PR DESCRIPTION
This PR corrects an incorrect mention of a step number in the **Deposit capital in France** guide. It should be step ~~4~~ 2—see [here](https://docs.swan.io/topics/capital-deposits/france/guide#:~:text=Follow%20the%20detailed%20guide%20to%20generate%20URLs%20and%20upload%20documents%2C%20which%20includes%20full%20API%20mutation%20examples).