### PR TITLE
DOC-1076 Add permission required for creating a payment link

### DIFF
--- a/docs/topics/merchants/partials/payment-links/_intro.mdx
+++ b/docs/topics/merchants/partials/payment-links/_intro.mdx
@@ -3,4 +3,4 @@ Create a [payment link](../../online/index.mdx#links) to accept {props.method} p
 :::tip Prerequisites
 - Merchant profile status: `Enabled`
 - Card payment method status: `Enabled`
-:::
+- Account member permission: `canManageAccountMembership`


### PR DESCRIPTION
Updated the partial to include the `canManageAccountMembership` permission requirement for creating payment links. 

The update shows up in the "Create a payment link" guides for [Cards](https://deploy-preview-313--incomparable-tiramisu-91a96a.netlify.app/topics/merchants/online/cards/guide-create-link) and [SDD](https://deploy-preview-313--incomparable-tiramisu-91a96a.netlify.app/topics/merchants/online/sdd/guide-create-link). 
