### PR TITLE
doc-714-update-expiration-delay-on-different-identification-levels

### DIFF
--- a/docs/topics/users/identifications/index.mdx
+++ b/docs/topics/users/identifications/index.mdx
@@ -148,7 +148,7 @@ flowchart LR
 | `Valid` | The user's identification was successful, determined by the service provider. |
 | `Invalid` | The user's identification wasn't successful, determined by the service provider. |
 | `Canceled` | An identification request is canceled by your user or Swan. Identifications can be canceled from any non-final status. You can't cancel an identification on your user's behalf. |
-| `Expired` | After a user starts an identification, they have a limited amount of time to complete it. If time expires, the identification status changes to `Expired`.<br /><br /><ul><li>Expert: 24 hours</li><li>QES: 24 hours</li><li>PVID: 15 minutes</li></ul> |
+| `Expired` | After a user starts an identification, they have a limited amount of time to complete it. If time expires, the identification status changes to `Expired`.<br /><br /><ul><li>Expert: 24 hours</li><li>QES: 2 hours</li><li>PVID: 15 minutes</li></ul> |
 | `NotSupported` | In the API, all levels (`Expert`, `QES`, and `PVID`) are displayed. For each identification, any level that doesn't meet your requirements is marked `NotSupported`.<br /><br />*For example, in an `Expert` identification, the `PVID` status is `NotSupported`.* |
 
 ### Invalid reason codes {#tracking-reason-codes}


### PR DESCRIPTION
Updated based on this [Linear ticket](https://linear.app/swan/issue/DOC-714/update-expiration-delay-on-different-identification-levels)