### PR TITLE
DOC-1125 Update identification recommendations for German account admins

### DIFF
--- a/docs/topics/onboarding/company/index.mdx
+++ b/docs/topics/onboarding/company/index.mdx
@@ -114,10 +114,10 @@ Swan must verify the identity of the [legal representative](../../../glossary.md
 Swan supports multiple [identification processes](../../users/identifications/index.mdx#levels-processes), and some require a [first transfer](../account-holders/index.mdx#first-transfer).
 For company onboarding, the following levels are recommended based on the account country.
 
-| Account country | Recommended level for legal representative | Other supported levels |
+| Account country | Recommended level for account admin | Other supported levels |
 |---|---|---|
 | 🇫🇷 France | **✓ Expert** | QES<br/>PVID |
-| 🇩🇪 Germany | **✓ Expert** | QES |
+| 🇩🇪 Germany | **✓ QES** | *none* |
 | 🇮🇹 Italy | **✓ Expert** | QES<br/>PVID |
 | 🇳🇱 Netherlands | **✓ Expert** | QES<br/>PVID |
 | 🇪🇸 Spain | **✓ Expert** | QES<br/>PVID |

--- a/docs/topics/users/identifications/index.mdx
+++ b/docs/topics/users/identifications/index.mdx
@@ -87,7 +87,7 @@ Sometimes, a [first transfer](../../onboarding/account-holders/index.mdx#first-t
 | Account country | Individual accounts | Company accounts |
 | --- | --- | --- |
 | 🇫🇷 France | **✓ PVID**<br />Expert + first transfer<br />QES | **✓ Expert**<br />QES<br />PVID |
-| 🇩🇪 Germany | **✓ QES + first transfer** | **✓ Expert**<br />QES |
+| 🇩🇪 Germany | **✓ QES + first transfer** | **✓ QES** |
 | 🇮🇹 Italy | ✓ **QES**<br />Expert + first transfer | **✓ Expert**<br /> QES<br />PVID |
 | 🇳🇱 Netherlands | **✓ Expert**<br />QES<br />PVID | **✓ Expert**<br />QES<br />PVID |
 | 🇪🇸 Spain | **✓ QES**<br />Expert + first transfer<br />PVID + first transfer | **✓ Expert**<br />QES<br />PVID |


### PR DESCRIPTION
Updated the identification recommendation for Germany. We've replaced "Expert" with "QES" identification.