### PR TITLE
DOC-931 Clarifying the ToRenew status

### DIFF
--- a/docs/topics/cards/physical/index.mdx
+++ b/docs/topics/cards/physical/index.mdx
@@ -363,7 +363,7 @@ flowchart LR
 
 | Card renewal status | Explanation |
 |---|---|
-| `ToRenew` | Status triggered automatically by the Swan API 10 weeks before the card's expiry date. Once this status is triggered, the renewal process can't be stopped unless the card is [canceled](./guide-cancel.mdx) or [suspended](#renew-suspended) and not resumed  **before** the 8-week mark. |
+| `ToRenew` | Status triggered 10 weeks before expiry to schedule a renewal. The process can be stopped either by [canceling](./guide-cancel.mdx) the card, which permanently ends the renewal, or by [suspending](#renew-suspended) it, which temporarily pauses the process. The card will not be renewed if it remains suspended past 8-weeks. |
 | `Renewed` | Status triggered automatically 8 weeks before the card's expiry date. No updates to the delivery address can be made after this status is triggered. |
 
 ### Suspended physical cards {#renew-suspended}


### PR DESCRIPTION
Hey, I added a bit more info explaining the `ToRenew` status - it can actually be stopped if a card is suspended or canceled.