### PR TITLE
DOCS-1798: clarify spending limit period switches [doc-1798]

### DIFF
--- a/docs/topics/cards/index.mdx
+++ b/docs/topics/cards/index.mdx
@@ -69,7 +69,7 @@ No matter how many members are attached to an account—1, 50, or 500—you can 
 Every member has access to the same pot of money.
 Any payments made with the card are debited from the account the member belongs to.
 
-Thus, an account membership must be created *before* adding a card for an account member.
+An account membership must be created *before* adding a card for an account member.
 
 Account members can also add cards for themselves or other account members, determined by their [membership permissions](../accounts/memberships/index.mdx#permissions-cards).
 
@@ -210,11 +210,16 @@ If a calendar period's reset date doesn't exist in a given month, the limit rese
 For example, if you set a monthly limit to reset on the 31st of February, the limit resets on the 28th of February (since February doesn't have a 31st).
 :::
 
+:::info Switching between rolling and calendar periods
+When you switch a card's limit from a rolling period to a calendar period (or vice versa), the spending limit does not start over. Swan applies the new time frame to the card's past purchases. This means any money already spent during the new period still counts toward the limit, ensuring your spending limits remain active and accurate.
+:::
+
 ### Limits imposed by Swan {#limits-swan}
 
 All spending limits imposed by Swan are for a rolling period of **1 month**.
 
-Note that **partners** (you) can define spending limits for all card types, while **account holders** can lower spending limits when creating cards.
+:::info **Partners** (you) can define spending limits for all card types, while **account holders** can lower spending limits when creating cards.
+:::
 
 | Transaction type | Impacts | Amount |
 | --- | --- | --- |
@@ -231,8 +236,8 @@ Consider the following examples:
     - Expenses for a single card can't exceed €10,000.
 - Individual account holder ATM withdrawal:
     - An **individual account holder** has two individual cards.
-    - They can withdrawal a maximum of €1,500 total between the 2 cards during a 30-day period.
-    - They **can't withdrawal** a total of €3,000—the maximum is per account holder.
+    - They can withdraw a maximum of €1,500 total between the 2 cards during a 30-day period.
+    - They **can't withdraw** a total of €3,000—the maximum is per account holder.
     - The €1,500 also counts toward their **card** transaction maximum of €5,000 per card.
 
 :::caution Changing spending limits

--- a/docs/topics/cards/index.mdx
+++ b/docs/topics/cards/index.mdx
@@ -218,7 +218,7 @@ When you switch a card's limit from a rolling period to a calendar period (or vi
 
 All spending limits imposed by Swan are for a rolling period of **1 month**.
 
-:::info 
+:::info
 **Partners** (you) can define spending limits for all card types, while **account holders** can lower spending limits when creating cards.
 :::
 

--- a/docs/topics/cards/index.mdx
+++ b/docs/topics/cards/index.mdx
@@ -211,14 +211,15 @@ For example, if you set a monthly limit to reset on the 31st of February, the li
 :::
 
 :::info Switching between rolling and calendar periods
-When you switch a card's limit from a rolling period to a calendar period (or vice versa), the spending limit does not start over. Swan applies the new time frame to the card's past purchases. This means any money already spent during the new period still counts toward the limit, ensuring your spending limits remain active and accurate.
+When you switch a card's limit from a rolling period to a calendar period (or vice versa), the spending limit doesn't start over. Swan applies the new time frame to the card's past purchases. This means any money already spent during the new period still counts toward the limit, ensuring your spending limits remain active and accurate.
 :::
 
 ### Limits imposed by Swan {#limits-swan}
 
 All spending limits imposed by Swan are for a rolling period of **1 month**.
 
-:::info **Partners** (you) can define spending limits for all card types, while **account holders** can lower spending limits when creating cards.
+:::info 
+**Partners** (you) can define spending limits for all card types, while **account holders** can lower spending limits when creating cards.
 :::
 
 | Transaction type | Impacts | Amount |

--- a/docs/topics/cards/index.mdx
+++ b/docs/topics/cards/index.mdx
@@ -211,7 +211,7 @@ For example, if you set a monthly limit to reset on the 31st of February, the li
 :::
 
 :::info Switching between rolling and calendar periods
-When you switch a card's limit from a rolling period to a calendar period (or vice versa), the spending limit doesn't start over. Swan applies the new time frame to the card's past purchases. This means any money already spent during the new period still counts toward the limit, ensuring your spending limits remain active and accurate.
+When you switch a card's limit from a rolling period to a calendar period (or vice versa), the spending limit doesn't reset. Swan applies the new time frame to the card's past purchases. This means any money already spent during the new period still counts toward the limit, ensuring your spending limits remain active and accurate.
 :::
 
 ### Limits imposed by Swan {#limits-swan}
@@ -238,7 +238,7 @@ Consider the following examples:
 - Individual account holder ATM withdrawal:
     - An **individual account holder** has two individual cards.
     - They can withdraw a maximum of €1,500 total between the 2 cards during a 30-day period.
-    - They **can't withdraw** a total of €3,000—the maximum is per account holder.
+    - They **can't withdraw** a total of €3,000. The maximum is per account holder.
     - The €1,500 also counts toward their **card** transaction maximum of €5,000 per card.
 
 :::caution Changing spending limits

--- a/docs/topics/cards/overview/guide-update.mdx
+++ b/docs/topics/cards/overview/guide-update.mdx
@@ -32,6 +32,10 @@ import SuspicionOfFraud from '../../partials/_card-fraud-suspicion.mdx';
 You can update spending limits with the `updateCard` mutation, including switching between [rolling and calendar periods](../index.mdx#limits-periods).
 Use the `spendingLimit` field to set the period, amount, and mode.
 
+:::info
+When you switch a card's limit from a rolling period to a calendar period (or vice versa), the spending limit does not start over. Swan applies the new time frame to the card's past purchases. For detailed behavior, see the [Spending limits](/topics/cards/#limits).
+:::
+
 ### Mutation {#mutation}
 
 <a href="https://explorer.swan.io?query=bXV0YXRpb24gVXBkYXRlQ2FyZFRyYW5zYWN0aW9uU2V0dGluZ3MgewogIHVwZGF0ZUNhcmQoCiAgICBpbnB1dDogewogICAgICBjYXJkSWQ6ICIkWU9VUl9DQVJEX0lEIgogICAgICB3aXRoZHJhd2FsOiBmYWxzZQogICAgICBpbnRlcm5hdGlvbmFsOiBmYWxzZQogICAgICBub25NYWluQ3VycmVuY3lUcmFuc2FjdGlvbnM6IGZhbHNlCiAgICAgIGVDb21tZXJjZTogZmFsc2UKICAgICAgY29uc2VudFJlZGlyZWN0VXJsOiAiJFlPVVJfQ09OU0VOVF9VUkwiCiAgICB9CiAgKSB7CiAgICAuLi4gb24gVXBkYXRlQ2FyZFN1Y2Nlc3NQYXlsb2FkIHsKICAgICAgX190eXBlbmFtZQogICAgICBjb25zZW50IHsKICAgICAgICBjb25zZW50VXJsCiAgICAgICAgaWQKICAgICAgfQogICAgfQogICAgLi4uIG9uIEFjY291bnROb3RGb3VuZFJlamVjdGlvbiB7CiAgICAgIGlkCiAgICAgIG1lc3NhZ2UKICAgIH0KICAgIC4uLiBvbiBDYXJkTm90Rm91bmRSZWplY3Rpb24gewogICAgICBpZAogICAgICBtZXNzYWdlCiAgICB9CiAgICAuLi4gb24gQWNjb3VudE1lbWJlcnNoaXBOb3RBbGxvd2VkUmVqZWN0aW9uIHsKICAgICAgX190eXBlbmFtZQogICAgICBtZXNzYWdlCiAgICB9CiAgICAuLi4gb24gVmFsaWRhdGlvblJlamVjdGlvbiB7CiAgICAgIF9fdHlwZW5hbWUKICAgICAgbWVzc2FnZQogICAgICBmaWVsZHMgewogICAgICAgIGNvZGUKICAgICAgICBtZXNzYWdlCiAgICAgICAgcGF0aAogICAgICB9CiAgICB9CiAgfQp9Cg%3D%3D&tab=api" className="explorer-badge">Open in API Explorer</a>

--- a/docs/topics/cards/overview/guide-update.mdx
+++ b/docs/topics/cards/overview/guide-update.mdx
@@ -33,7 +33,7 @@ You can update spending limits with the `updateCard` mutation, including switchi
 Use the `spendingLimit` field to set the period, amount, and mode.
 
 :::info
-When you switch between rolling and calendar periods, the spending limit doesn't start over. For details, see [Spending limits](/topics/cards/#limits).
+When you switch between rolling and calendar periods, the spending limit doesn't reset. For details, see [Spending limits](/topics/cards/#limits).
 :::
 
 ### Mutation {#mutation}

--- a/docs/topics/cards/overview/guide-update.mdx
+++ b/docs/topics/cards/overview/guide-update.mdx
@@ -33,7 +33,7 @@ You can update spending limits with the `updateCard` mutation, including switchi
 Use the `spendingLimit` field to set the period, amount, and mode.
 
 :::info
-When you switch a card's limit from a rolling period to a calendar period (or vice versa), the spending limit does not start over. Swan applies the new time frame to the card's past purchases. For detailed behavior, see the [Spending limits](/topics/cards/#limits).
+When you switch between rolling and calendar periods, the spending limit doesn't start over. For details, see [Spending limits](/topics/cards/#limits).
 :::
 
 ### Mutation {#mutation}

--- a/docs/topics/partials/_cards-overview.mdx
+++ b/docs/topics/partials/_cards-overview.mdx
@@ -4,4 +4,4 @@ Swan cards are accepted everywhere Mastercard is accepted, though there can be r
 
 Individual account holders are issued consumer debit cards, while company account holders receive business debit cards.
 The fee per card depends on your contract with Swan and is detailed in your Swan Terms and Conditions.
-Note that cards don't come with insurance.
+Insurance coverage depends on your card package tier. Refer to [card packages](./card-packages) for more detail.

--- a/docs/topics/partials/_cards-overview.mdx
+++ b/docs/topics/partials/_cards-overview.mdx
@@ -4,4 +4,4 @@ Swan cards are accepted everywhere Mastercard is accepted, though there can be r
 
 Individual account holders are issued consumer debit cards, while company account holders receive business debit cards.
 The fee per card depends on your contract with Swan and is detailed in your Swan Terms and Conditions.
-Insurance coverage depends on your card package tier. Refer to [card packages](./card-packages) for more detail.
+Insurance coverage depends on your card package tier. Refer to [card packages](/topics/cards/card-packages) for more detail.


### PR DESCRIPTION
Updated based on Linear ticket, also some minor grammar edits.